### PR TITLE
Add automatic installation of pysap-mri, pysap and pynufft / pynfft to docker image

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,2 @@
+cmake
+libnfft3-dev

--- a/apt.txt
+++ b/apt.txt
@@ -1,2 +1,3 @@
 cmake
 libnfft3-dev
+libgl1-mesa-glx

--- a/environments.yml
+++ b/environments.yml
@@ -1,6 +1,0 @@
-name: base
-channels:
-  - anaconda
-  - defaults
-dependencies:
-  - cmake

--- a/environments.yml
+++ b/environments.yml
@@ -3,25 +3,4 @@ channels:
   - anaconda
   - defaults
 dependencies:
-  - cmake=3.14.0=h52cb24c_0
-  - pip:
-    - astropy==2.0.8
-    - matplotlib==3.1.1
-    - modopt==1.4.1
-    - nibabel==2.4.1
-    - numpy==1.17.3
-    - pip==19.3.1
-    - pipreqs==0.4.9
-    - progressbar2==3.42.0
-    - pybind11==2.3.0
-    - pynfft==1.3.2
-    - pynufft==2019.2.0
-    - pyqt5==5.13.0
-    - pyqt5-sip==4.19.18
-    - pyqtgraph==0.10.0
-    - pytest-runner==5.2
-    - python-utils==2.3.0
-    - retrying==1.3.3
-    - scikit-image==0.16.1
-    - python-pysap
-    - pysap-mri
+  - cmake

--- a/environments.yml
+++ b/environments.yml
@@ -1,0 +1,27 @@
+name: base
+channels:
+  - anaconda
+  - defaults
+dependencies:
+  - cmake=3.14.0=h52cb24c_0
+  - pip:
+    - astropy==2.0.8
+    - matplotlib==3.1.1
+    - modopt==1.4.1
+    - nibabel==2.4.1
+    - numpy==1.17.3
+    - pip==19.3.1
+    - pipreqs==0.4.9
+    - progressbar2==3.42.0
+    - pybind11==2.3.0
+    - pynfft==1.3.2
+    - pynufft==2019.2.0
+    - pyqt5==5.13.0
+    - pyqt5-sip==4.19.18
+    - pyqtgraph==0.10.0
+    - pytest-runner==5.2
+    - python-utils==2.3.0
+    - retrying==1.3.3
+    - scikit-image==0.16.1
+    - python-pysap
+    - pysap-mri

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ python-pysap
 scikit-image
 git+git://github.com/jyhmiinlin/pynufft@master#egg=pynufft
 cython
-git+git://github.com/cea-cosmic/pysap-mri@master#pysap-mri
+pysap-mri
+git+git://github.com/ghisvail/pyNFFT/tarball/master#egg=pynfft-1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy==1.16.*
+matplotlib==3.*
+scikit-image
+python-pysap
+pysap-mri

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ python-pysap
 scikit-image
 git+git://github.com/jyhmiinlin/pynufft@master#egg=pynufft
 cython
-pynfft
+git+git://github.com/cea-cosmic/pysap-mri@master#pysap-mri

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-pysap
 scikit-image
-git+git://https://github.com/jyhmiinlin/pynufft@master#egg=pynufft
+git+git://github.com/jyhmiinlin/pynufft@master#egg=pynufft
 cython
 pynfft

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-pysap
+scikit-image

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ scikit-image
 git+git://github.com/jyhmiinlin/pynufft@master#egg=pynufft
 cython
 pysap-mri
-git+git://github.com/ghisvail/pyNFFT/tarball/master#egg=pynfft-1.3.0
+git+git://github.com/ghisvail/pyNFFT@master#egg=pynfft-1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 python-pysap
 scikit-image
+git+git://https://github.com/jyhmiinlin/pynufft@master#egg=pynufft
+cython
+pynfft

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-numpy==1.16.*
-matplotlib==3.*
-scikit-image
-python-pysap
-pysap-mri


### PR DESCRIPTION
Hello,
This PR basically adds apt.txt and requirements.txt so that direct launch with binder would allow for use of pysap and pynfft libraries without any installation.
