### PR TITLE
Fix for Pynfft2

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-pip install python-pysap pysap-mri>=0.3.0 modopt>=1.5.2 pynfft2
+pip install python-pysap pysap-mri>=0.3.0 modopt>=1.5.2 
+pip install --uprade modopt
+pip install pynfft2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 pip>=20
 setuptools>=60.0.0
 pyqt5==5.13.0
+numpy>=1.20.0
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 pip>=20
 setuptools>=60.0.0
 pyqt5==5.13.0
-numpy>=1.20.0
-


### PR DESCRIPTION
Fix pynfft2 requirements through updated numpy in build

This should ideally fix the problem. however binder is taking too long to run for me at the moment